### PR TITLE
Update Fypp.cmake

### DIFF
--- a/Fypp.cmake
+++ b/Fypp.cmake
@@ -22,7 +22,7 @@ foreach(infileName ${ARGN})
     # Custom command to do the processing
     add_custom_command(
         OUTPUT "${outfile}"
-	COMMAND ${CMAKE_SOURCE_DIR}/bin/fypp "${FYPP_FLAGS}" "${infile}" "${outfile}"
+	COMMAND ${CMAKE_SOURCE_DIR}/bin/fypp ${FYPP_FLAGS} "${infile}" "${outfile}"
         MAIN_DEPENDENCY "${infile}"
        	DEPENDS macros.fypp
         VERBATIM)


### PR DESCRIPTION
Remove quotes arround FYPP flags to prevent
the preprocessor from interpreting empty flags
as a missing file.